### PR TITLE
Update as many deps as possible.

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-    "publish-delay-hours": 1
+    "automerge-flathubbot-prs": true
 }

--- a/io.github.Soundux.yml
+++ b/io.github.Soundux.yml
@@ -96,5 +96,11 @@ modules:
           version-query: .tag_name
           url-query: .assets[] | select(.name|endswith(".tar.gz")) | .browser_download_url
     post-install:
-      - mv yt-dlp youtube-dl
-      - install -Dm0755 -t /app/bin youtube-dl
+      - install -Dm0755 -t /app/bin yt-dlp
+  - name: youtube-dl-compat
+    buildsystem: simple
+    build-commands:
+    - install -Dm0755 -t /app/bin youtube-dl
+    sources:
+      - type: file
+        path: youtube-dl

--- a/io.github.Soundux.yml
+++ b/io.github.Soundux.yml
@@ -1,6 +1,6 @@
 app-id: io.github.Soundux
 runtime: org.gnome.Platform
-runtime-version: "42"
+runtime-version: '42'
 sdk: org.gnome.Sdk
 command: soundux
 finish-args:
@@ -16,33 +16,44 @@ finish-args:
   - --filesystem=/run/media:ro
   - --filesystem=/media:ro
 modules:
-  - "shared-modules/libappindicator/libappindicator-gtk3-introspection-12.10.json"
+  - shared-modules/libappindicator/libappindicator-gtk3-introspection-12.10.json
   - name: libwnck
     buildsystem: meson
     config-opts:
-      - "-Dgtk_doc=false"
+      - -Dgtk_doc=false
     cleanup:
-      - "/include"
-      - "/lib/pkgconfig"
-      - "/bin"
+      - /include
+      - /lib/pkgconfig
+      - /bin
     sources:
       - type: git
         url: https://gitlab.gnome.org/GNOME/libwnck.git
-        tag: "40.0"
-        commit: "d161ed31914711b97a1c6ebef0558d80ce51113b"
+        tag: '40.0'
+        commit: d161ed31914711b97a1c6ebef0558d80ce51113b
+        x-checker-data:
+          type: gnome
+          name: libwnck
+          versions:
+            '=': '40.0'
+          stable-only: true
   - name: soundux
     buildsystem: cmake-ninja
     config-opts:
       - -DUSE_FLATPAK=ON
       - -DCMAKE_BUILD_TYPE=Release
     post-install:
-      - "install -Dm 644 -t /app/share/metainfo deployment/appstream/io.github.Soundux.metainfo.xml"
-      - "install -Dm 644 -t /app/share/applications deployment/appstream/io.github.Soundux.desktop"
-      - "install -Dm 644 deployment/flatpak/icons/io.github.Soundux-256.png /app/share/icons/hicolor/256x256/apps/io.github.Soundux.png"
+      - install -Dm 644 -t /app/share/metainfo deployment/appstream/io.github.Soundux.metainfo.xml
+      - install -Dm 644 -t /app/share/applications deployment/appstream/io.github.Soundux.desktop
+      - install -Dm 644 deployment/flatpak/icons/io.github.Soundux-256.png /app/share/icons/hicolor/256x256/apps/io.github.Soundux.png
     sources:
       - type: archive
-        url: https://github.com/Soundux/Soundux/releases/download/0.2.8/soundux-0.2.8.tar.gz
-        sha256: d007841ae5bab71d8a25cc86d27ce137b01b29a7f2b42a5bd62b4ed50dd74043
+        url: https://github.com/Soundux/Soundux/releases/download/0.2.7/soundux-0.2.7.tar.gz
+        sha512: e813be41d324536065a1f98d397027b98a9db504faed7abb074bd0cc6ac65a7804d120cc559c5fa509acf39ff851aa74d02c4da0f3c49ad8f01286cb81776bd3
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/Soundux/Soundux/releases/latest
+          version-query: .tag_name
+          url-query: .assets[] | select(.name|endswith(".tar.gz")) | .browser_download_url
         strip-components: 2
   - name: ffmpeg
     config-opts:
@@ -56,21 +67,27 @@ modules:
       - --enable-libvorbis
     sources:
       - type: archive
-        url: https://www.ffmpeg.org/releases/ffmpeg-5.0.1.tar.xz
-        sha256: ef2efae259ce80a240de48ec85ecb062cecca26e4352ffb3fda562c21a93007b
+        url: https://www.ffmpeg.org/releases/ffmpeg-5.1.4.tar.xz
+        sha512: 7d7fe8c660a62971a979553a864648d5c859059d3e64d4d32e4f5dca6fd4374270abdeec2dd782c34b2254e7485995c3fe0c1dcef54159e30536eab7f20e0795
     post-install:
       - install -Dm644 COPYING.LGPLv3 /app/share/licenses/ffmpeg/COPYING
     cleanup:
-      - "/share/ffmpeg"
-  - name: youtube-dl
+      - /share/ffmpeg
+  - name: yt-dlp
     no-autogen: true
     no-make-install: true
     make-args:
-      - youtube-dl
+      - yt-dlp
       - PYTHON=/usr/bin/python
     sources:
       - type: archive
-        url: https://github.com/ytdl-org/youtube-dl/releases/download/2021.12.17/youtube-dl-2021.12.17.tar.gz
-        sha256: 9f3b99c8b778455165b4525f21505e86c7ff565f3ac319e19733d810194135df
+        url: https://github.com/yt-dlp/yt-dlp/releases/download/2023.12.30/yt-dlp.tar.gz
+        sha512: 23062e61cae9c51436f16de0a5ee0b351e59554ab4b5b90bed819d98b6b677bfd1797abae5baf52964eb64236c4b7abe23e37ca88ed10cbce3f7356081be59c4
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest
+          version-query: .tag_name
+          url-query: .assets[] | select(.name|endswith(".tar.gz")) | .browser_download_url
     post-install:
+      - mv yt-dlp youtube-dl
       - install -Dm0755 -t /app/bin youtube-dl

--- a/io.github.Soundux.yml
+++ b/io.github.Soundux.yml
@@ -34,7 +34,7 @@ modules:
           type: gnome
           name: libwnck
           versions:
-            '=': '40.0'
+            '==': '40.0'
           stable-only: true
   - name: soundux
     buildsystem: cmake-ninja

--- a/io.github.Soundux.yml
+++ b/io.github.Soundux.yml
@@ -67,8 +67,15 @@ modules:
       - --enable-libvorbis
     sources:
       - type: archive
-        url: https://www.ffmpeg.org/releases/ffmpeg-5.1.4.tar.xz
-        sha512: 7d7fe8c660a62971a979553a864648d5c859059d3e64d4d32e4f5dca6fd4374270abdeec2dd782c34b2254e7485995c3fe0c1dcef54159e30536eab7f20e0795
+        url: https://www.ffmpeg.org/releases/ffmpeg-6.1.1.tar.xz
+        sha512: fca3f8635f29182e3ae0fe843a8a53614e4b47e22c11508df3ff7cdbafbb4b5ee0d82d9b3332871f7c1032033b1cad2f67557d7c5f7f7d85e2adadca122965d5
+        x-checker-data:
+          type: anitya
+          project-id: 5405
+          versions:
+            '>=': '5.0'
+          stable-only: true
+          url-template: https://www.ffmpeg.org/releases/ffmpeg-$version.tar.xz
     post-install:
       - install -Dm644 COPYING.LGPLv3 /app/share/licenses/ffmpeg/COPYING
     cleanup:

--- a/io.github.Soundux.yml
+++ b/io.github.Soundux.yml
@@ -27,13 +27,13 @@ modules:
       - /bin
     sources:
       - type: archive
-        url: https://download.gnome.org/sources/libwnck/40/libwnck-40.1.tar.xz
-        sha256: 03134fa114ef3fbe34075aa83678f58aa2debe9fcef4ea23c0779e28601d6611
+        url: https://download.gnome.org/sources/libwnck/43/libwnck-43.0.tar.xz
+        sha256: 905bcdb85847d6b8f8861e56b30cd6dc61eae67ecef4cd994a9f925a26a2c1fe
         x-checker-data:
           type: gnome
           name: libwnck
           versions:
-            <=: '40.1'
+            '>=': '40.0'
           url-template: https://download.gnome.org/sources/libwnck/$major/libwnck-$version.tar.xz
           stable-only: true
   - name: soundux

--- a/io.github.Soundux.yml
+++ b/io.github.Soundux.yml
@@ -26,15 +26,15 @@ modules:
       - /lib/pkgconfig
       - /bin
     sources:
-      - type: git
-        url: https://gitlab.gnome.org/GNOME/libwnck.git
-        tag: '40.0'
-        commit: d161ed31914711b97a1c6ebef0558d80ce51113b
+      - type: archive
+        url: https://download.gnome.org/sources/libwnck/40/libwnck-40.1.tar.xz
+        sha256: 03134fa114ef3fbe34075aa83678f58aa2debe9fcef4ea23c0779e28601d6611
         x-checker-data:
           type: gnome
           name: libwnck
           versions:
-            '==': '40.0'
+            <=: '40.1'
+          url-template: https://download.gnome.org/sources/libwnck/$major/libwnck-$version.tar.xz
           stable-only: true
   - name: soundux
     buildsystem: cmake-ninja

--- a/youtube-dl
+++ b/youtube-dl
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+yt-dlp --compat-options youtube-dl "$@"


### PR DESCRIPTION
While updating this application to use a newer runtime would be nice, it seems like some dependencies are causing issues (See https://github.com/flathub/io.github.Soundux/pull/64)

Despite this we can at least fix some of the issues that are a bit annoying. Primarily the issues with downloading from youtube, or other sites.

I also added x-data-checker for all deps, to help with maintenance.

Here's a high-level overview of the changes:

Update ffmpeg to latest release.
Replace youtube-dl with yt-dlp (fixes many download issues with youtube and other sites. Pinned release is also many years newer.)
Roll back Soundux to v0.2.7 from now non-existant v0.2.8 release.