### PR TITLE
Rely on the ffmpeg install provided in the Gnome Platform runtime.

### DIFF
--- a/io.github.Soundux.yml
+++ b/io.github.Soundux.yml
@@ -73,31 +73,6 @@ modules:
           url: https://api.github.com/repos/yhirose/cpp-httplib/releases/latest
           version-query: .tag_name
           url-query: .tarball_url
-  - name: ffmpeg
-    config-opts:
-      - --enable-shared
-      - --disable-static
-      - --disable-doc
-      - --disable-ffplay
-      - --disable-devices
-      - --enable-gnutls
-      - --enable-libmp3lame
-      - --enable-libvorbis
-    sources:
-      - type: archive
-        url: https://www.ffmpeg.org/releases/ffmpeg-7.0.1.tar.xz
-        sha512: 94e06c4ce64ed3888620547db0e33b29c68a9e78b3ea748346f34280f69723a6d4b7485911f45f1849f9aa3036c0699334abbcf7126d2763bdaa7276673b7daa
-        x-checker-data:
-          type: anitya
-          project-id: 5405
-          versions:
-            '>=': '5.0'
-          stable-only: true
-          url-template: https://www.ffmpeg.org/releases/ffmpeg-$version.tar.xz
-    post-install:
-      - install -Dm644 COPYING.LGPLv3 /app/share/licenses/ffmpeg/COPYING
-    cleanup:
-      - /share/ffmpeg
   - name: yt-dlp
     no-autogen: true
     no-make-install: true


### PR DESCRIPTION
When testing some of my own local Flatpaks I found that I could access the ffmpeg binary via the runtime. It seems to support the same codecs as specified in the ffmpeg module, plus a bunch of extras.

Merging this should save time when building, and save space in the final flatpak since we aren't shipping another version of ffmpeg. Additionally, the runtime manages that dependency already which is great.

If you'd like to test conversion, try downloading: https://sample-videos.com/video321/mp4/720/big_buck_bunny_720p_2mb.mp4 in Soundux.

It appears to be converted successfully to an MP3 with it's sound is playable correctly.
