### PR TITLE
Update to GNOME 48 runtime.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build-dir
 
 _build
 _repo
+io.github.Soundux.flatpak

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .flatpak-builder
 build-dir
+
+_build
+_repo

--- a/io.github.Soundux.yml
+++ b/io.github.Soundux.yml
@@ -1,6 +1,6 @@
 app-id: io.github.Soundux
 runtime: org.gnome.Platform
-runtime-version: '46'
+runtime-version: '48'
 sdk: org.gnome.Sdk
 command: soundux-startup
 finish-args:
@@ -58,9 +58,11 @@ modules:
           url-query: .assets[] | select(.name|endswith(".tar.gz")) | .browser_download_url
         strip-components: 2
       - type: patch
-        path: webviewpp-build-fix.patch
-      - type: patch
         path: guardpp-build-fix.patch
+      - type: patch
+        path: pipewire-build-fix.patch
+      - type: patch
+        path: webviewpp-build-fix.patch
       - type: file
         path: soundux-startup
       - type: archive

--- a/local-build.sh
+++ b/local-build.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -e  # Exit immediately if a command exits with a non-zero status
+
+BRANCH="test"
+
+# Function to print error messages
+error() {
+    echo "Error: $1" >&2
+    exit 1
+}
+
+# Function to check if a command exists
+check_command() {
+    local cmd="$1"
+    if ! command -v "$cmd" &> /dev/null; then
+        error "$cmd is not installed. Please install $cmd and try again."
+    fi
+    echo "$cmd is installed."
+}
+
+# Check if flatpak is installed
+check_command "flatpak"
+
+# Check if flatpak-builder is installed
+check_command "flatpak-builder"
+
+# Define required Flatpak packages
+REQUIRED_FLATPAK_PACKAGES=(
+    "org.gnome.Platform//46"
+    "org.gnome.Sdk//46"
+)
+
+# Function to check if a Flatpak package is installed
+is_flatpak_installed() {
+    local package="$1"
+    flatpak info "$package" &> /dev/null
+}
+
+# Install missing Flatpak packages
+for package in "${REQUIRED_FLATPAK_PACKAGES[@]}"; do
+    if is_flatpak_installed "$package"; then
+        echo "Flatpak package '$package' is already installed."
+    else
+        echo "Flatpak package '$package' is not installed. Installing..."
+        flatpak install -y flathub "$package" || error "Failed to install $package"
+    fi
+done
+
+# Update Flatpak repositories
+echo "Updating Flatpak repositories..."
+flatpak update -y || error "Failed to update Flatpak repositories"
+
+# Clean previous build artifacts
+echo "Cleaning previous build artifacts..."
+rm -f io.github.Soundux.flatpak
+rm -rf _build _repo
+mkdir _build _repo
+
+# Build the Flatpak
+echo "Building the Flatpak..."
+flatpak-builder --ccache --force-clean --default-branch="$BRANCH" _build io.github.Soundux.yml --repo=_repo || error "flatpak-builder failed"
+
+# Bundle the Flatpak
+echo "Bundling the Flatpak..."
+flatpak build-bundle _repo io.github.Soundux.flatpak io.github.Soundux "$BRANCH" || error "flatpak build-bundle failed"
+
+echo "Flatpak build and bundle completed successfully."

--- a/local-build.sh
+++ b/local-build.sh
@@ -27,8 +27,8 @@ check_command "flatpak-builder"
 
 # Define required Flatpak packages
 REQUIRED_FLATPAK_PACKAGES=(
-    "org.gnome.Platform//46"
-    "org.gnome.Sdk//46"
+    "org.gnome.Platform//48"
+    "org.gnome.Sdk//48"
 )
 
 # Function to check if a Flatpak package is installed

--- a/pipewire-build-fix.patch
+++ b/pipewire-build-fix.patch
@@ -1,0 +1,10 @@
+--- a/src/helper/audio/linux/pipewire/pipewire.cpp	2025-05-08 21:29:28.370071131 -0400
++++ b/src/helper/audio/linux/pipewire/pipewire.cpp	2025-05-08 21:29:02.905407829 -0400
+@@ -1,6 +1,7 @@
+ #if defined(__linux__)
+ #include "pipewire.hpp"
+ #include "forward.hpp"
++#include <algorithm>
+ #include <fancy.hpp>
+ #include <memory>
+ #include <nlohmann/json.hpp>


### PR DESCRIPTION
I noticed the deprecation message for Gnome 46 when updating my Flatpak packages so I figured I'd drop a patch here :smile: 

I also added a local build script (local-build.sh) which makes testing the flatpak locally a breeze.

To get things building I had to add a header to `src/helper/audio/linux/pipewire/pipewire.cpp` for this to build correctly with the newer version of GCC the runtime is using: https://github.com/flathub/io.github.Soundux/blob/8748fe23533aacafc701bbb15444dcabb6fbb3f9/pipewire-build-fix.patch

After this patch was applied the application builds correctly.

I also tested the application and all seems to run correctly.

Let me know if you want me to make any changes 😄