### PR TITLE
Fix NVIDIA White Screen Issue when launching Soundux via the desktop file

### DIFF
--- a/io.github.Soundux.yml
+++ b/io.github.Soundux.yml
@@ -44,6 +44,8 @@ modules:
       - -DCMAKE_CXX_FLAGS=-Wno-error=deprecated-declarations
     post-install:
       - install -Dm 644 -t /app/share/metainfo deployment/appstream/io.github.Soundux.metainfo.xml
+      # Patch the desktop file to use the wrapper to fix the white screen issue
+      - desktop-file-edit --set-key=Exec --set-value='soundux-startup %U' deployment/appstream/io.github.Soundux.desktop
       - install -Dm 644 -t /app/share/applications deployment/appstream/io.github.Soundux.desktop
       - install -Dm 644 deployment/flatpak/icons/io.github.Soundux-256.png /app/share/icons/hicolor/256x256/apps/io.github.Soundux.png
       - install -Dm 755 -t /app/bin soundux-startup


### PR DESCRIPTION
This fix ensures the installed desktop file also uses the soundux-startup wrapper.
See for context: https://discord.com/channels/697348809591750706/1279814590678437950

Previously the `soundux-startup` wrapper script was created to workaround the white screen issue on NVIDIA GPUs. 

Funnily enough it looks like this fix only sticks if you are running Soundux via the terminal as the wrapper script is being run and not soundux directly.

This correctly launches the wrapper from the desktop as well to ensure the fix works.